### PR TITLE
Improvements to Modbus handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Next version
+
+### ✨ Improved
+
+* [#32](https://github.com/sdss/lvmecp/pull/32) Major refactor of the `Modbus` and `ModbusRegister` classes. The main change is that the performance has been greatly improved, with `Modbus.get_all()` going from taking ~0.6 seconds to under 0.1. The register and coil blocks are now read completely, in chunks as large as the device will accept, as opposed to before, when we would read each variable with one read command (although the connection was not closed in between). Note that several methods and variables have been renamed; see the PR for details.
+
+
 ## 1.0.2 - December 27, 2024
 
 ### ✨ Improved

--- a/python/lvmecp/actor/commands/dome.py
+++ b/python/lvmecp/actor/commands/dome.py
@@ -74,7 +74,12 @@ async def close(command: ECPCommand, force=False):
 async def status(command: ECPCommand):
     """Returns the status of the dome."""
 
-    status = await command.actor.plc.dome.update(use_cache=False)
+    status = await command.actor.plc.dome.update(
+        use_cache=False,
+        force_output=True,
+        command=command,
+    )
+
     if status is None:
         return command.fail("Failed retrieving dome status.")
 
@@ -84,7 +89,7 @@ async def status(command: ECPCommand):
     if status & DomeStatus.POSITION_UNKNOWN:
         command.warning("Dome position is unknown!!!")
 
-    return command.finish(dome_open=bool(status & DomeStatus.OPEN))
+    return command.finish()
 
 
 @dome.command()
@@ -101,9 +106,7 @@ async def stop(command: ECPCommand):
 async def reset(command: ECPCommand, force=False):
     """Resets dome error state."""
 
-    try:
-        await command.actor.plc.dome.reset()
-    except DomeError as err:
-        return command.fail(err)
+    command.warning("Resetting dome error state.")
+    await command.actor.plc.dome.reset()
 
     return command.finish()

--- a/python/lvmecp/actor/commands/engineering.py
+++ b/python/lvmecp/actor/commands/engineering.py
@@ -34,12 +34,13 @@ async def get_eng_mode_status(actor: ECPActor) -> dict:
         ends_at = started_at + duration
 
     return {
-            "enabled": enabled,
-            "started_at": timestamp_to_iso(started_at),
-            "ends_at": timestamp_to_iso(ends_at),
-            "software_override": registers["engineering_mode_software"],
-            "hardware_override": registers["engineering_mode_hardware"],
-        }
+        "enabled": enabled,
+        "started_at": timestamp_to_iso(started_at),
+        "ends_at": timestamp_to_iso(ends_at),
+        "software_override": registers["engineering_mode_software"],
+        "hardware_override": registers["engineering_mode_hardware"],
+    }
+
 
 @parser.group(name="engineering-mode")
 def engineering_mode():

--- a/python/lvmecp/actor/commands/modbus.py
+++ b/python/lvmecp/actor/commands/modbus.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# @Author: José Sánchez-Gallego (gallegoj@uw.edu)
+# @Date: 2024-12-28
+# @Filename: modbus.py
+# @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
+
+from __future__ import annotations
+
+import asyncio
+
+from typing import TYPE_CHECKING
+
+import click
+
+from . import parser
+
+
+if TYPE_CHECKING:
+    from lvmecp.actor import ECPCommand
+    from lvmecp.modbus import ModbusRegister
+
+
+def get_register(command: ECPCommand, address_or_name: str):
+    """Returns a register from an address or name."""
+
+    plc = command.actor.plc
+
+    register: ModbusRegister | None = None
+    try:
+        address = int(address_or_name)  # type: ignore
+        for _, reg in plc.modbus.items():
+            if reg.address == address:
+                register = reg
+                break
+    except ValueError:
+        register = plc.modbus.get(address_or_name)
+
+    if register is None:
+        command.fail(f"Register {address!r} not found.")
+        return False
+
+    return register
+
+
+@parser.group()
+def modbus():
+    """Low-level access to the PLC Modbus variables."""
+
+    pass
+
+
+@modbus.command()
+@click.argument("address", metavar="ADDRESS|NAME")
+async def read(command: ECPCommand, address: str):
+    """Reads a Modbus register."""
+
+    if not (register := get_register(command, address)):
+        return False
+
+    value = await register.read(use_cache=False)
+
+    return command.finish(
+        register={
+            "name": register.name,
+            "address": register.address,
+            "value": value,
+        }
+    )
+
+
+@modbus.command()
+@click.argument("address", metavar="ADDRESS|NAME")
+@click.argument("value", type=int)
+async def write(command: ECPCommand, address: str, value: int):
+    """Writes a value to a Modbus register."""
+
+    if not (register := get_register(command, address)):
+        return False
+
+    name = register.name
+
+    if register.readonly:
+        return command.fail(f"Register {name!r} is read-only.")
+
+    if register.mode == "coil":
+        try:
+            value = bool(int(value))
+        except Exception:
+            return command.fail(f"Invalid value for coil register {name!r}: {value!r}")
+        else:
+            value = int(value)
+
+    await register.write(value)
+
+    await asyncio.sleep(0.5)
+    new_value = await register.read(use_cache=False)
+
+    return command.finish(
+        register={
+            "name": name,
+            "address": register.address,
+            "value": new_value,
+        }
+    )

--- a/python/lvmecp/dome.py
+++ b/python/lvmecp/dome.py
@@ -189,8 +189,8 @@ class DomeController(PLCModule[DomeStatus]):
     async def reset(self):
         """Resets the roll-off error state."""
 
-        await self.modbus["rolloff_error_reset"].write(True)
-        await asyncio.sleep(1)
+        await self.modbus["dome_error_reset"].write(True)
+        await asyncio.sleep(0.5)
 
     def is_allowed(self):
         """Returns whether the dome is allowed to move."""

--- a/python/lvmecp/dome.py
+++ b/python/lvmecp/dome.py
@@ -23,6 +23,9 @@ from lvmecp.maskbits import DomeStatus
 from lvmecp.module import PLCModule
 
 
+MOVE_CHECK_INTERVAL: float = 0.5
+
+
 class DomeController(PLCModule[DomeStatus]):
     """Controller for the rolling dome."""
 
@@ -125,17 +128,17 @@ class DomeController(PLCModule[DomeStatus]):
         log.debug("Setting motor_direction.")
         await self.modbus["motor_direction"].write(open)
 
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(0.1)
 
         log.debug("Setting drive_enabled.")
         await self.modbus["drive_enabled"].write(True)
 
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(0.1)
 
         last_enabled: float = 0.0
         while True:
             # Still moving.
-            await asyncio.sleep(2)
+            await asyncio.sleep(MOVE_CHECK_INTERVAL)
 
             drive_enabled = await self.modbus["drive_enabled"].read(use_cache=False)
 

--- a/python/lvmecp/etc/lvmecp.yml
+++ b/python/lvmecp/etc/lvmecp.yml
@@ -498,6 +498,12 @@ simulator:
         register: e_status
         action: reset
         reset_trigger: true
+    dome_error_reset:
+      on_value: 1
+      then:
+        register: dome_error
+        action: reset
+        reset_trigger: true
 
 engineering_mode:
   default_duration: 300
@@ -512,7 +518,7 @@ dome:
   full_open_mm: 9480
 
 actor:
-  name: lvmecp-dev
+  name: lvmecp
   host: localhost
   port: 5672
   log_dir: /data/logs/lvmecp

--- a/python/lvmecp/etc/lvmecp.yml
+++ b/python/lvmecp/etc/lvmecp.yml
@@ -159,7 +159,7 @@ modbus:
       group: dome
       readonly: true
     dome_speed:
-      address: 150
+      address: 151
       mode: holding_register
       group: dome
       readonly: true
@@ -243,6 +243,11 @@ modbus:
       mode: coil
       readonly: true
       group: safety
+    rain_sensor_count:
+      address: 699
+      mode: holding_register
+      readonly: true
+      group: safety
     rain_sensor_countdown:
       address: 700
       mode: holding_register
@@ -258,15 +263,6 @@ modbus:
       mode: coil
       readonly: false
       group: engineering_mode
-
-safety:
-  override_local_mode: False
-  o2_threshold: 19.5
-
-dome:
-  daytime_allowed: false
-  daytime_tolerance: 600
-  anti_flap_tolerance: [3, 600]
 
 hvac:
   host: 10.8.38.49
@@ -443,8 +439,17 @@ hvac:
 engineering_mode:
   default_duration: 300
 
+safety:
+  o2_threshold: 19.5
+
+dome:
+  daytime_allowed: false
+  daytime_tolerance: 600
+  anti_flap_tolerance: [3, 600]
+  full_open_mm: 9480
+
 actor:
-  name: lvmecp
+  name: lvmecp-dev
   host: localhost
   port: 5672
   log_dir: /data/logs/lvmecp

--- a/python/lvmecp/etc/lvmecp.yml
+++ b/python/lvmecp/etc/lvmecp.yml
@@ -436,6 +436,69 @@ hvac:
       mode: coil
       readonly: true
 
+simulator:
+  host: 127.0.0.1
+  port: 5020
+  overrides:
+    door_locked: true
+    door_closed: true
+    dome_closed: true
+  events:
+    ur_new:
+      on_value: 1
+      then:
+        register: ur_status
+        action: toggle
+        reset_trigger: true
+    cr_new:
+      on_value: 1
+      then:
+        register: cr_status
+        action: toggle
+        reset_trigger: true
+    sr_new:
+      on_value: 1
+      then:
+        register: sr_status
+        action: toggle
+        reset_trigger: true
+    uma_new:
+      on_value: 1
+      then:
+        register: uma_status
+        action: toggle
+        reset_trigger: true
+    tb_new:
+      on_value: 1
+      then:
+        register: tb_status
+        action: toggle
+        reset_trigger: true
+    tr_new:
+      on_value: 1
+      then:
+        register: tr_status
+        action: toggle
+        reset_trigger: true
+    hb_set:
+      on_value: 1
+      then:
+        register: hb_ack
+        action: set
+        reset_trigger: true
+    e_stop:
+      on_value: 1
+      then:
+        register: e_status
+        action: set
+        reset_trigger: true
+    e_relay_reset:
+      on_value: 1
+      then:
+        register: e_status
+        action: reset
+        reset_trigger: true
+
 engineering_mode:
   default_duration: 300
 

--- a/python/lvmecp/etc/lvmecp.yml
+++ b/python/lvmecp/etc/lvmecp.yml
@@ -1,172 +1,263 @@
 modbus:
   host: 10.8.38.51
   port: 502
-  cache_timeout: 0.5
+  cache_timeout: 1
   registers:
     door_locked:
       address: 0
       group: safety
+      mode: coil
+      readonly: true
     door_closed:
       address: 1
       group: safety
+      mode: coil
+      readonly: true
     local:
       address: 2
       group: safety
+      mode: coil
+      readonly: true
     e_status:
-      address: 200
-      group: safety
-    e_stop:
       address: 199
       group: safety
+      mode: coil
+      readonly: true
+    e_stop:
+      address: 200
+      group: safety
+      mode: coil
+      readonly: false
     e_relay_reset:
       address: 201
       group: safety
+      mode: coil
+      readonly: false
     cr_new:
       address: 234
       group: lights
+      mode: coil
+      readonly: false
     cr_status:
       address: 334
       group: lights
+      mode: coil
+      readonly: true
     ur_new:
       address: 235
       group: lights
+      mode: coil
+      readonly: false
     ur_status:
       address: 335
       group: lights
+      mode: coil
+      readonly: true
     sr_new:
       address: 236
       group: lights
+      mode: coil
+      readonly: false
     sr_status:
       address: 336
       group: lights
+      mode: coil
+      readonly: true
     uma_new:
       address: 237
       group: lights
+      mode: coil
+      readonly: false
     uma_status:
       address: 337
       group: lights
+      mode: coil
+      readonly: true
     tb_new:
       address: 238
       group: lights
+      mode: coil
+      readonly: false
     tb_status:
       address: 338
       group: lights
+      mode: coil
+      readonly: true
     tr_new:
       address: 239
       group: lights
+      mode: coil
+      readonly: false
     tr_status:
       address: 339
       group: lights
+      mode: coil
+      readonly: true
     drive_enabled:
       address: 99
       group: dome
-    drive_state:
-      address: 100
-      group: dome
+      mode: coil
+      readonly: false
     motor_direction:
       address: 101
       group: dome
-    drive_brake:
-      address: 102
-      group: dome
+      mode: coil
+      readonly: false
     ne_limit:
       address: 104
       group: dome
+      mode: coil
+      readonly: true
     se_limit:
       address: 105
       group: dome
+      mode: coil
+      readonly: true
     nw_limit:
       address: 106
       group: dome
+      mode: coil
+      readonly: true
     sw_limit:
       address: 107
       group: dome
+      mode: coil
+      readonly: true
     dome_closed:
       address: 108
       group: dome
+      mode: coil
+      readonly: true
     dome_open:
       address: 109
       group: dome
-    # overcurrent:
-    #   address: 109
-    #   group: dome
-    drive_velocity1:
-      address: 103
-      mode: holding_register
+      mode: coil
+      readonly: true
+    dome_lockout:
+      address: 110
       group: dome
-    drive_velocity2:
-      address: 104
-      mode: holding_register
+      mode: coil
+      readonly: true
+    dome_error:
+      address: 111
       group: dome
-    open_timeout:
-      address: 119
-      mode: holding_register
+      mode: coil
+      readonly: true
+    dome_error_reset:
+      address: 112
       group: dome
-    close_timeout:
-      address: 120
-      mode: holding_register
-      group: dome
-    drive_current:
-      address: 129
-      mode: holding_register
-      group: dome
+      mode: coil
+      readonly: false
     dome_counter:
       address: 149
       mode: holding_register
       group: dome
+      readonly: true
+    dome_position:
+      address: 150
+      mode: holding_register
+      group: dome
+      readonly: true
+    dome_speed:
+      address: 150
+      mode: holding_register
+      group: dome
+      readonly: true
     dome_status1:
       address: 410
       mode: holding_register
       group: dome
+      readonly: true
     dome_status2:
       address: 411
       mode: holding_register
       group: dome
-    rolloff_lockout:
-      address: 110
+      readonly: true
+    dome_set_frequency:
+      address: 412
+      mode: holding_register
       group: dome
-    rolloff_error:
-      address: 111
+      readonly: true
+    dome_output_frequency:
+      address: 413
+      mode: holding_register
       group: dome
-    rolloff_error_reset:
-      address: 112
+      readonly: true
+    dome_output_current:
+      address: 129
+      mode: holding_register
       group: dome
+      readonly: true
+    dome_output_voltage:
+      address: 416
+      mode: holding_register
+      group: dome
+      readonly: true
+    dome_motor_current_rpm:
+      address: 417
+      mode: holding_register
+      group: dome
+      readonly: true
+    dome_present_fault_record:
+      address: 399
+      mode: holding_register
+      group: dome
+      readonly: true
     oxygen_read_utilities_room:
       address: 599
       mode: holding_register
       group: safety
+      readonly: true
     oxygen_read_spectrograph_room:
       address: 600
       mode: holding_register
       group: safety
-    oxygen_mode_utilities_room:
+      readonly: true
+    oxygen_error_code_utilities_room:
       address: 601
       mode: holding_register
       group: safety
-    oxygen_mode_spectrograph_room:
+      readonly: true
+    oxygen_error_code_spectrograph_room:
       address: 602
       mode: holding_register
       group: safety
+      readonly: true
     hb_set:
       address: 599
       mode: coil
+      readonly: false
       group: safety
     hb_ack:
       address: 600
       mode: coil
+      readonly: true
       group: safety
     hb_error:
       address: 601
       mode: coil
+      readonly: true
       group: safety
     rain_sensor_alarm:
       address: 699
       mode: coil
+      readonly: true
       group: safety
-    rain_sensor_counter:
-      address: 699
+    rain_sensor_countdown:
+      address: 700
       mode: holding_register
+      readonly: true
       group: safety
+    engineering_mode_hardware:
+      address: 899
+      mode: coil
+      readonly: false
+      group: engineering_mode
+    engineering_mode_software:
+      address: 900
+      mode: coil
+      readonly: false
+      group: engineering_mode
 
 safety:
   override_local_mode: False
@@ -187,135 +278,167 @@ hvac:
       mode: holding_register
       count: 2
       decoder: float_32bit
+      readonly: true
     hvac_flowmeter_ahu_spectrograph:
       address: 2
       mode: holding_register
       count: 2
       decoder: float_32bit
+      readonly: true
     hvac_exterior_humidity:
       address: 4
       mode: holding_register
       count: 2
       decoder: float_32bit
+      readonly: true
     hvac_humidity_utilities_room:
       address: 6
       mode: holding_register
       count: 2
       decoder: float_32bit
+      readonly: true
     hvac_humidity_spectrograph_room:
       address: 8
       mode: holding_register
       count: 2
       decoder: float_32bit
+      readonly: true
     hvac_humidity_telescope_platform:
       address: 10
       mode: holding_register
       count: 2
       decoder: float_32bit
+      readonly: true
     hvac_water_pressure_inlet_circuit_1:
       address: 12
       mode: holding_register
       count: 2
       decoder: float_32bit
+      readonly: true
     hvac_water_pressure_inlet_circuit_2:
       address: 14
       mode: holding_register
       count: 2
       decoder: float_32bit
+      readonly: true
     hvac_exterior_temperature:
       address: 16
       mode: holding_register
       count: 2
       decoder: float_32bit
+      readonly: true
     hvac_utilities_room_temperature:
       address: 18
       mode: holding_register
       count: 2
       decoder: float_32bit
+      readonly: true
     hvac_spectrograph_room_temperature:
       address: 20
       mode: holding_register
       count: 2
       decoder: float_32bit
+      readonly: true
     hvac_telescope_platform_temperature:
       address: 22
       mode: holding_register
       count: 2
       decoder: float_32bit
+      readonly: true
     hvac_chiller_in_water_temperature:
       address: 24
       mode: holding_register
       count: 2
       decoder: float_32bit
+      readonly: true
     hvac_ahu_in_water_temperature:
       address: 26
       mode: holding_register
       count: 2
       decoder: float_32bit
+      readonly: true
     hvac_ahu_injection_temperature:
       address: 28
       mode: holding_register
       count: 2
       decoder: float_32bit
+      readonly: true
     hvac_ahu_return_temperature:
       address: 30
       mode: holding_register
       count: 2
       decoder: float_32bit
+      readonly: true
     hvac_chiller_out_temperature:
       address: 32
       mode: holding_register
       count: 2
       decoder: float_32bit
+      readonly: true
     hvac_ahu_out_temperature:
       address: 34
       mode: holding_register
       count: 2
       decoder: float_32bit
+      readonly: true
     hvac_ahu_cold_valve:
       address: 36
       mode: holding_register
       count: 2
       decoder: float_32bit
+      readonly: true
     hvac_system_status:
       address: 0
       mode: coil
+      readonly: true
     hvac_ahu_filter_status:
       address: 1
       mode: coil
+      readonly: true
     hvac_vin_1_air_pressure:
       address: 2
       mode: coil
+      readonly: true
     hvac_vin_2_air_pressure:
       address: 3
       mode: coil
+      readonly: true
     hvac_roll_off_roof_position:
       address: 4
       mode: coil
+      readonly: true
     hvac_status_damper_1:
       address: 5
       mode: coil
+      readonly: true
     hvac_status_damper_2:
       address: 6
       mode: coil
+      readonly: true
     hvac_ahu_heater_1:
       address: 7
       mode: coil
+      readonly: true
     hvac_start_stop_chiller:
       address: 8
       mode: coil
+      readonly: true
     hvac_start_stop_vin_1:
       address: 9
       mode: coil
+      readonly: true
     hvac_start_stop_vin_2:
       address: 10
       mode: coil
+      readonly: true
     hvac_start_stop_water_pump:
       address: 11
       mode: coil
+      readonly: true
     hvac_start_stop_ahu:
       address: 12
       mode: coil
+      readonly: true
 
 engineering_mode:
   default_duration: 300

--- a/python/lvmecp/etc/schema.json
+++ b/python/lvmecp/etc/schema.json
@@ -18,9 +18,9 @@
         }
       }
     },
-    "lights": {
-      "type": "string"
-    },
+    "lights": { "type": "string" },
+    "lights_labels": { "type": "string" },
+    "dome_percent_open": { "type": "number" },
     "o2_percent_utilities": { "type": "number" },
     "o2_percent_spectrograph": { "type": "number" },
     "heartbeat_ack": {
@@ -57,5 +57,5 @@
       "required": ["enabled", "started_at", "ends_at"]
     }
   },
-  "additionalProperties": true
+  "additionalProperties": false
 }

--- a/python/lvmecp/etc/schema.json
+++ b/python/lvmecp/etc/schema.json
@@ -23,8 +23,23 @@
     },
     "o2_percent_utilities": { "type": "number" },
     "o2_percent_spectrograph": { "type": "number" },
-    "last_heartbeat_set": {
+    "heartbeat_ack": {
       "oneOf": [{ "type": "string" }, { "type": "null" }]
+    },
+    "register": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "address": { "type": "number" },
+        "value": {
+          "oneOf": [
+            { "type": "boolean" },
+            { "type": "number" },
+            { "type": "null" }
+          ]
+        }
+      },
+      "required": ["name", "value"]
     },
     "engineering_mode": {
       "type": "object",
@@ -35,7 +50,9 @@
         },
         "ends_at": {
           "oneOf": [{ "type": "string" }, { "type": "null" }]
-        }
+        },
+        "software_override": { "type": "boolean" },
+        "hardware_override": { "type": "boolean" }
       },
       "required": ["enabled", "started_at", "ends_at"]
     }

--- a/python/lvmecp/hvac.py
+++ b/python/lvmecp/hvac.py
@@ -23,9 +23,9 @@ class HVACController(PLCModule):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.status: dict[str, float | bool | None] = {}
+        self.status: dict[str, int | bool] = {}
 
     async def _update_internal(self, **kwargs):
         """Update status."""
 
-        self.status = await self.modbus.get_all()
+        self.status = await self.modbus.read_all()

--- a/python/lvmecp/lights.py
+++ b/python/lvmecp/lights.py
@@ -123,7 +123,7 @@ class LightsController(PLCModule):
         code = self.get_code(light)
 
         log.debug(f"Toggling light {code}.")
-        await self.modbus[f"{code}_new"].set(True)
+        await self.modbus[f"{code}_new"].write(True)
 
         await asyncio.sleep(0.5)
         await self.update(use_cache=False)

--- a/python/lvmecp/lights.py
+++ b/python/lvmecp/lights.py
@@ -43,7 +43,7 @@ class LightsController(PLCModule):
     flag = LightStatus
     interval = 30.0
 
-    async def _update_internal(self, use_cache: bool = True):
+    async def _update_internal(self, use_cache: bool = True, **kwargs):
         """Update status."""
 
         assert self.flag is not None

--- a/python/lvmecp/maskbits.py
+++ b/python/lvmecp/maskbits.py
@@ -54,6 +54,9 @@ class SafetyStatus(Maskbit):
     O2_SENSOR_SR_ALARM = 0x400  # Spec room
     O2_SENSOR_SR_FAULT = 0x800
     RAIN_SENSOR_ALARM = 0x1000
+    E_STOP = 0x2000
+    DOME_LOCKED = 0x4000
+    DOME_ERROR = 0x8000
     UNKNOWN = 0x100000
 
 

--- a/python/lvmecp/modbus.py
+++ b/python/lvmecp/modbus.py
@@ -12,8 +12,9 @@ import asyncio
 import pathlib
 from time import time
 
-from typing import cast
+from typing import Literal, Sequence
 
+from lvmopstools.retrier import Retrier
 from pymodbus.client.tcp import AsyncModbusTcpClient
 from pymodbus.constants import Endian
 from pymodbus.payload import BinaryPayloadDecoder
@@ -24,10 +25,15 @@ from sdsstools.utils import cancel_task
 from lvmecp import config as lvmecp_config
 from lvmecp import log
 from lvmecp.exceptions import ECPError
+from lvmecp.tools import TimedCacheDict
 
 
 MAX_RETRIES = 3
-TIMEOUT = 10.0
+MAX_COUNT_HR = 100
+CONNECTION_TIMEOUT = 10.0
+
+
+RegisterModes = Literal["coil", "holding_regiser", "discrete_input", "input_register"]
 
 
 class ModbusRegister:
@@ -47,6 +53,8 @@ class ModbusRegister:
         or ``input_register``.
     group
         A grouping key for registers.
+    readonly
+        Whether the register is read-only.
 
     """
 
@@ -55,10 +63,11 @@ class ModbusRegister:
         modbus: Modbus,
         name: str,
         address: int,
-        mode: str = "coil",
+        mode: RegisterModes = "coil",
         count: int = 1,
         group: str | None = None,
         decoder: str | None = None,
+        readonly: bool = True,
     ):
         self.modbus = modbus
         self.client = modbus.client
@@ -69,17 +78,10 @@ class ModbusRegister:
         self.count = count
         self.group = group
         self.decoder = decoder
+        self.readonly = readonly
 
-        self._last_value: int | float = 0
-        self._last_seen: float = 0
-
-    async def _get_internal(self, use_cache: bool = True):
+    async def _read_internal(self):
         """Return the value of the modbus register."""
-
-        cache_timeout = self.modbus.cache_timeout
-        last_seen_interval = time() - self._last_seen
-        if use_cache and last_seen_interval < cache_timeout:
-            return self._last_value
 
         if self.mode == "coil":
             func = self.client.read_coils
@@ -92,19 +94,12 @@ class ModbusRegister:
         else:
             raise ValueError(f"Invalid block mode {self.mode!r}.")
 
-        if self.client.connected:
+        async with self.modbus:
             resp = await func(
                 self.address,
                 count=self.count,
                 slave=self.modbus.slave,
-            )  # type: ignore
-        else:
-            async with self.modbus:
-                resp = await func(
-                    self.address,
-                    count=self.count,
-                    slave=self.modbus.slave,
-                )  # type: ignore
+            )
 
         if resp.function_code > 0x80:
             raise ValueError(
@@ -119,87 +114,84 @@ class ModbusRegister:
             registers = resp.registers
             value = registers[0 : self.count] if self.count > 1 else registers[0]
 
-            if self.decoder is not None:
-                if self.decoder == "float_32bit":
-                    bin_payload = BinaryPayloadDecoder.fromRegisters(
-                        value,
-                        byteorder=Endian.BIG,
-                        wordorder=Endian.LITTLE,
-                    )
-                    value = round(bin_payload.decode_32bit_float(), 3)
-                else:
-                    raise ValueError(f"Unknown decoder {self.decoder}")
+        value = self.decode(value)
 
         if not isinstance(value, (int, float)):
             raise ValueError(f"Invalid type for {self.name!r} response.")
 
-        self._last_value = value
-        self._last_seen = time()
+        return value
+
+    def decode(self, value: int | bool | list[int | bool]):
+        """Decodes the raw value from the register."""
+
+        if self.decoder is not None:
+            if self.decoder == "float_32bit":
+                bin_payload = BinaryPayloadDecoder.fromRegisters(
+                    value,
+                    byteorder=Endian.BIG,
+                    wordorder=Endian.LITTLE,
+                )
+                value = round(bin_payload.decode_32bit_float(), 3)
+            else:
+                raise ValueError(f"Unknown decoder {self.decoder}")
 
         return value
 
-    async def get(self, open_connection: bool = True, use_cache: bool = True):
-        """Return the value of the modbus register. Implements retry."""
+    @Retrier(max_attempts=MAX_RETRIES, delay=0.5, max_delay=2.0)
+    async def read(self, use_cache: bool = True):
+        """Return the value of the modbus register.
 
-        for ntries in range(1, MAX_RETRIES + 1):
-            # If we need to open the connection, use the Modbus context
-            # and call ourselves recursively with open_connection=False
-            # (at that point it will be open).
-            if open_connection:
-                await self.modbus.connect()
+        Parameters
+        ----------
+        use_cache
+            Whether to use the cache to retrieve the value. If the cache is not
+            available, or the value is not in the cache, the register will be read.
+            This function does not set the cache after reading the register.
 
-            if not self.modbus.client or not self.modbus.client.connected:
-                raise ConnectionError("Not connected to modbus server.")
+        """
 
-            try:
-                return await self._get_internal(use_cache=use_cache)
-            except Exception:
-                if ntries >= MAX_RETRIES:
-                    raise
+        if use_cache:
+            cache = self.modbus.register_cache
+            if self.name in cache and (value := cache[self.name]) is not None:
+                return value
 
-                await asyncio.sleep(0.5)
-            finally:
-                if open_connection:
-                    await self.modbus.disconnect()
+        return await self._read_internal()
 
-    async def set(self, value: int | bool):
+    @Retrier(max_attempts=MAX_RETRIES, delay=0.5, max_delay=2.0)
+    async def write(self, value: int | bool):
         """Sets the value of the register."""
 
-        for ntries in range(1, MAX_RETRIES + 1):
-            # Always open the connection.
-            async with self.modbus:
-                if self.mode == "coil":
-                    func = self.client.write_coil
-                elif self.mode == "holding_register":
-                    func = self.client.write_register
-                elif self.mode == "discrete_input" or self.mode == "input_register":
-                    raise ValueError(f"Block of mode {self.mode!r} is read-only.")
+        if self.readonly:
+            raise ECPError(f"Register {self.name!r} is read-only.")
+
+        # Always open the connection.
+        async with self.modbus:
+            if self.mode == "coil":
+                func = self.client.write_coil
+            elif self.mode == "holding_register":
+                func = self.client.write_register
+            elif self.mode == "discrete_input" or self.mode == "input_register":
+                raise ValueError(f"Block of mode {self.mode!r} is read-only.")
+            else:
+                raise ValueError(f"Invalid block mode {self.mode!r}.")
+
+            try:
+                if self.client.connected:
+                    resp = await func(self.address, value)  # type: ignore
                 else:
-                    raise ValueError(f"Invalid block mode {self.mode!r}.")
-
-                try:
-                    if self.client.connected:
+                    async with self.modbus:
                         resp = await func(self.address, value)  # type: ignore
-                    else:
-                        async with self.modbus:
-                            resp = await func(self.address, value)  # type: ignore
 
-                    if resp.function_code > 0x80:
-                        raise ECPError(
-                            f"Invalid response for element "
-                            f"{self.name!r}: 0x{resp.function_code:02X}."
-                        )
-                    else:
-                        self._last_value = int(value)
-                        self._last_seen = time()
+                if resp.function_code > 0x80:
+                    raise ECPError(
+                        f"Invalid response for element "
+                        f"{self.name!r}: 0x{resp.function_code:02X}."
+                    )
+                else:
+                    self.modbus.register_cache[self.name] = value
 
-                        return
-
-                except Exception as err:
-                    if ntries >= MAX_RETRIES:
-                        raise ECPError(f"Failed setting {self.name!r}: {err}")
-
-                await asyncio.sleep(0.5)
+            except Exception as err:
+                raise ECPError(f"Failed setting {self.name!r}: {err}")
 
 
 class Modbus(dict[str, ModbusRegister]):
@@ -232,40 +224,42 @@ class Modbus(dict[str, ModbusRegister]):
         self.port = self.config["port"]
         self.slave = self.config.get("slave", 0)
 
-        # Cache results so that very close calls to get_all() don't need to
-        # open a connection and read the registers.
-        self.cache_timeout = self.config.get("cache_timeout", 0.5)
-        self._register_cache: dict[str, int | float | None] = {}
-        self._register_last_seen: float = 0
+        # Cache results so that very close calls to get_all()
+        # don't need to open a connection and read the registers.
+        self.cache_timeout = self.config.get("cache_timeout", 1)
+        self.register_cache = TimedCacheDict(self.cache_timeout, mode="null")
 
+        # Modbus client.
         self.client = AsyncModbusTcpClient(self.host, port=self.port)
 
-        self.lock = asyncio.Lock()
-        self._lock_release_task: asyncio.Task | None = None
+        # Semaphore to allow up to 5 concurrent connections.
+        self.semaphore = asyncio.Semaphore(1)
+        self._semaphore_release_task: asyncio.Task | None = None
 
-        register_data = self.config["registers"]
+        # Create the internal dictionary of registers
         registers = {
             name: ModbusRegister(
                 self,
                 name,
-                elem["address"],
-                mode=elem.get("mode", "coil"),
-                group=elem.get("group", None),
-                count=elem.get("count", 1),
-                decoder=elem.get("decoder", None),
+                register["address"],
+                mode=register.get("mode", "coil"),
+                group=register.get("group", None),
+                count=register.get("count", 1),
+                decoder=register.get("decoder", None),
+                readonly=register.get("readonly", True),
             )
-            for name, elem in register_data.items()
+            for name, register in self.config["registers"].items()
         }
 
         dict.__init__(self, registers)
-        for name, elem in registers.items():
-            setattr(self, name, elem)
+        for name, register in registers.items():
+            setattr(self, name, register)
 
     async def connect(self):
         """Connects to the client."""
 
         try:
-            await asyncio.wait_for(self.lock.acquire(), TIMEOUT)
+            await asyncio.wait_for(self.semaphore.acquire(), CONNECTION_TIMEOUT)
         except asyncio.TimeoutError:
             raise RuntimeError("Timed out waiting for lock to be released.")
 
@@ -282,15 +276,15 @@ class Modbus(dict[str, ModbusRegister]):
         except Exception as err:
             raise ConnectionError(f"Failed connecting to server at {hp}: {err}.")
         finally:
-            if not did_connect and self.lock.locked():
-                self.lock.release()
+            if not did_connect:
+                self.semaphore.release()
 
         log.debug(f"Connected to {hp}.")
 
         # Schedule a task to release the lock after 5 seconds. This is a safeguard
         # in case something fails and the connection is never closed and the lock
         # not released.
-        self._lock_release_task = asyncio.create_task(self.unlock_on_timeout())
+        self._semaphore_release_task = asyncio.create_task(self.unlock_on_timeout())
 
     async def disconnect(self):
         """Disconnects the client."""
@@ -301,10 +295,9 @@ class Modbus(dict[str, ModbusRegister]):
                 log.debug(f"Disonnected from {self.host}:{self.port}.")
 
         finally:
-            if self.lock.locked():
-                self.lock.release()
+            self.semaphore.release()
 
-            await cancel_task(self._lock_release_task)
+            await cancel_task(self._semaphore_release_task)
 
     async def __aenter__(self):
         """Initialises the connection to the server."""
@@ -319,50 +312,97 @@ class Modbus(dict[str, ModbusRegister]):
     async def unlock_on_timeout(self):
         """Removes the lock after an amount of time."""
 
-        await asyncio.sleep(TIMEOUT)
-        if self.lock.locked():
-            self.lock.release()
+        await asyncio.sleep(CONNECTION_TIMEOUT)
+        self.semaphore.release()
 
-    async def get_all(self, use_cache: bool = True):
-        """Returns a dictionary with all the registers."""
+    async def read_all(self, use_cache: bool = True) -> dict[str, int | bool]:
+        """Returns a dictionary with all the registers and sets the cache."""
 
-        if use_cache and time() - self._register_last_seen < self.cache_timeout:
-            if None not in self._register_cache.values():
-                return self._register_cache
+        if use_cache:
+            oldest_cache = min(self.register_cache._cache_time.values())
+            if time() - oldest_cache < self.cache_timeout:
+                return self.register_cache.freeze()
 
-        names = results = []
-
+        # With this PLC it is more efficient to read the entire coil and
+        # holding register blocks in one go, and then parse the results, as
+        # opposed to reading each register individually.
         async with self:
-            names = [name for name in self]
-            tasks = [
-                elem.get(open_connection=False, use_cache=False)
-                for elem in self.values()
-            ]
+            for mode in ["coil", "holding_register"]:
+                mode_count = max(
+                    register.address + register.count
+                    for register in self.values()
+                    if register.mode == mode
+                )
 
-            results = await asyncio.gather(*tasks, return_exceptions=True)
+                if mode == "coil":
+                    func = self.client.read_coils
+                elif mode == "holding_register":
+                    func = self.client.read_holding_registers
+                else:
+                    raise ValueError(f"Invalid mode {mode!r}.")
 
-        if any([isinstance(result, Exception) for result in results]):
-            for ii, result in enumerate(results):
-                if isinstance(result, Exception):
-                    log.warning(f"Failed retrieving value for {names[ii]!r}")
-                    results[ii] = None
+                data: list[int | bool] = []
 
-        registers = cast(
-            dict[str, int | float | None],
-            {names[ii]: results[ii] for ii in range(len(names))},
-        )
+                if mode == "coil":
+                    # For coils we can read the entire block.
+                    resp = await func(0, count=1023, slave=self.slave)
 
-        self._register_cache = registers
-        self._register_last_seen = time()
+                    if resp.isError():
+                        raise ValueError(
+                            f"Invalid response for block {mode!r}: "
+                            f"0x{resp.function_code:02X}."
+                        )
+
+                    data += resp.bits
+
+                else:
+                    # For holding registers we are limited to reading MAX_COUNT_HR
+                    # at once. We iterate to get all the data.
+                    n_reads = mode_count // MAX_COUNT_HR + 1
+
+                    for nn in range(n_reads):
+                        resp = await func(
+                            nn * MAX_COUNT_HR,
+                            count=MAX_COUNT_HR,
+                            slave=self.slave,
+                        )
+
+                        if resp.isError():
+                            raise ValueError(
+                                f"Invalid response for block {mode!r}: "
+                                f"0x{resp.function_code:02X}."
+                            )
+
+                        data += resp.registers
+
+                for name, register in self.items():
+                    if register.mode != mode:
+                        continue
+
+                    value = data[register.address : register.address + register.count]
+                    value = register.decode(value)
+
+                    if isinstance(value, Sequence) and len(value) == 1:
+                        value = value[0]
+
+                    self.register_cache[name] = value
+
+        registers = self.register_cache.freeze()
+
+        # Just to double check that none of the values have expired, we loop over the
+        # dictionary and if necessary we read the register again.
+        for name, value in registers.items():
+            if value is None:
+                registers[name] = await self[name].read(use_cache=False)
 
         return registers
 
     async def read_group(self, group: str, use_cache: bool = True):
         """Returns a dictionary of all read registers that match a ``group``."""
 
-        registers = await self.get_all(use_cache=use_cache)
+        registers = await self.read_all(use_cache=use_cache)
 
-        group_registers = {}
+        group_registers: dict[str, int | bool] = {}
         for name in self:
             register = self[name]
             if register.group is not None and register.group == group:
@@ -372,3 +412,23 @@ class Modbus(dict[str, ModbusRegister]):
                 group_registers[name] = registers[name]
 
         return group_registers
+
+    async def write_register(self, register: str | int, value: int | bool):
+        """Writes a value to a register."""
+
+        if isinstance(register, int):
+            for name, reg in self.items():
+                if reg.address == register:
+                    register = name
+                    found = True
+                    break
+
+            if not found:
+                raise ValueError(f"Register with address {register!r} not found.")
+
+        assert isinstance(register, str)
+
+        if register not in self:
+            raise ValueError(f"Register {register!r} not found.")
+
+        await self[register].write(value)

--- a/python/lvmecp/modbus.py
+++ b/python/lvmecp/modbus.py
@@ -33,7 +33,7 @@ MAX_COUNT_HR = 100
 CONNECTION_TIMEOUT = 10.0
 
 
-RegisterModes = Literal["coil", "holding_regiser", "discrete_input", "input_register"]
+RegisterModes = Literal["coil", "holding_register", "discrete_input", "input_register"]
 
 
 class ModbusRegister:

--- a/python/lvmecp/modbus.py
+++ b/python/lvmecp/modbus.py
@@ -319,7 +319,8 @@ class Modbus(dict[str, ModbusRegister]):
         """Returns a dictionary with all the registers and sets the cache."""
 
         if use_cache:
-            oldest_cache = min(self.register_cache._cache_time.values())
+            cache_times = self.register_cache._cache_time.values()
+            oldest_cache = min(cache_times) if len(cache_times) > 0 else 0
             if time() - oldest_cache < self.cache_timeout:
                 return self.register_cache.freeze()
 

--- a/python/lvmecp/modbus.py
+++ b/python/lvmecp/modbus.py
@@ -418,6 +418,7 @@ class Modbus(dict[str, ModbusRegister]):
         """Writes a value to a register."""
 
         if isinstance(register, int):
+            found: bool = False
             for name, reg in self.items():
                 if reg.address == register:
                     register = name

--- a/python/lvmecp/module.py
+++ b/python/lvmecp/module.py
@@ -47,7 +47,7 @@ class PLCModule(abc.ABC, Generic[Flag_co]):
         modbus: Modbus | None = None,
         interval: float | None = None,
         start: bool = True,
-        notifier: Callable[[int, str], Callable | Coroutine] | None = None,
+        notifier: Callable[[int, str, dict], Callable | Coroutine] | None = None,
     ):
         self.name = name
         self.plc = plc
@@ -159,5 +159,6 @@ class PLCModule(abc.ABC, Generic[Flag_co]):
                 self.notifier,
                 status.value,
                 str(status),
+                extra_keywords,
                 **kwargs,
             )

--- a/python/lvmecp/module.py
+++ b/python/lvmecp/module.py
@@ -114,6 +114,7 @@ class PLCModule(abc.ABC, Generic[Flag_co]):
         except Exception as err:
             log.warning(f"{self.name}: failed updating status: {err}")
             new_status = self.flag(self.flag.__unknown__) if self.flag else None
+            extra_info = {}
 
         # Only notify if the status has changed.
         if (new_status != self.status and not extra_info) or force_output:

--- a/python/lvmecp/safety.py
+++ b/python/lvmecp/safety.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 import math
+import time
 from types import SimpleNamespace
 
 from lvmecp.maskbits import SafetyStatus
@@ -26,6 +27,8 @@ class SafetyController(PLCModule[SafetyStatus]):
 
         self.o2_level_utilities: float = math.nan
         self.o2_level_spectrograph: float = math.nan
+
+        self.last_heartbeat_ack: float | None = None
 
     async def _update_internal(self, use_cache: bool = True, **kwargs):
         assert self.flag is not None
@@ -51,32 +54,40 @@ class SafetyController(PLCModule[SafetyStatus]):
         self.o2_level_utilities = safety_status.oxygen_read_utilities_room / 10.0
         if self.o2_level_utilities < self.plc.config["safety"]["o2_threshold"]:
             new_status |= self.flag.O2_SENSOR_UR_ALARM
-        if safety_status.oxygen_mode_utilities_room == 8:
+        if safety_status.oxygen_error_code_utilities_room == 8:
             new_status |= self.flag.O2_SENSOR_UR_FAULT
 
         # Spectrograph room O2 sensor
         self.o2_level_spectrograph = safety_status.oxygen_read_spectrograph_room / 10.0
         if self.o2_level_spectrograph < self.plc.config["safety"]["o2_threshold"]:
             new_status |= self.flag.O2_SENSOR_SR_ALARM
-        if safety_status.oxygen_mode_spectrograph_room == 8:
+        if safety_status.oxygen_error_code_spectrograph_room == 8:
             new_status |= self.flag.O2_SENSOR_SR_FAULT
 
         # Rain sensor
         if safety_status.rain_sensor_alarm:
             new_status |= self.flag.RAIN_SENSOR_ALARM
 
+        # E-stop
+        if safety_status.e_status:
+            new_status |= self.flag.E_STOP
+
+        # Dome lockout and error
+        if await self.plc.modbus["dome_lockout"].read():
+            new_status |= self.flag.DOME_LOCKED
+        if await self.plc.modbus["dome_error"].read():
+            new_status |= self.flag.DOME_ERROR
+
         if new_status.value == 0:
             new_status = self.flag(self.flag.__unknown__)
+
+        if await self.plc.modbus["hb_ack"].read():
+            self.last_heartbeat_ack = time.time()
 
         return new_status
 
     async def is_remote(self):
         """Returns `True` if NOT in local mode (i.e., safe to operate remotely)."""
-
-        safety_config = self.plc.config.get("safety", {})
-        override_local = safety_config.get("override_local_mode", False)
-        if override_local:
-            return True
 
         await self.update()
         assert self.status is not None and self.flag is not None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,10 @@ import os
 from contextlib import suppress
 from copy import deepcopy
 
+from typing import cast
+
 import pytest
+from pymodbus.datastore import ModbusSlaveContext
 
 from clu.testing import setup_test_actor
 
@@ -35,6 +38,13 @@ async def simulator():
     with suppress(asyncio.CancelledError):
         simulator_task.cancel()
         await simulator_task
+
+
+@pytest.fixture()
+def context(simulator: Simulator) -> ModbusSlaveContext:
+    assert simulator.context
+
+    return cast(ModbusSlaveContext, simulator.context[0])
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,7 @@ async def actor(simulator: Simulator, mocker):
 
     _actor = ECPActor.from_config(ecp_config)
 
-    mocker.patch.object(_actor.plc.hvac.modbus, "get_all", return_value={})
+    mocker.patch.object(_actor.plc.hvac.modbus, "read_all", return_value={})
 
     _actor = await setup_test_actor(_actor)  # type: ignore
     _actor.connection.connection = mocker.MagicMock(spec={"is_closed": False})

--- a/tests/test_command_dome.py
+++ b/tests/test_command_dome.py
@@ -21,9 +21,76 @@ from lvmecp.maskbits import DomeStatus
 
 
 if TYPE_CHECKING:
+    from pymodbus.datastore import ModbusSlaveContext
     from pytest_mock import MockerFixture
 
     from lvmecp.actor import ECPActor
+
+
+@pytest.mark.parametrize("open", [True, False])
+async def test_command_dome_status(
+    context: ModbusSlaveContext, actor: ECPActor, open: bool
+):
+    if open:
+        address = actor.plc.modbus["dome_open"].address
+    else:
+        address = actor.plc.modbus["dome_closed"].address
+
+    context.setValues(1, address, [1])
+
+    cmd = await actor.invoke_mock_command("dome status")
+    await cmd
+
+    assert cmd.status.did_succeed
+
+
+async def test_command_dome_moving(context: ModbusSlaveContext, actor: ECPActor):
+    address = actor.plc.modbus["drive_enabled"].address
+
+    context.setValues(1, address, [1])
+
+    cmd = await actor.invoke_mock_command("dome status")
+    await cmd
+
+    assert cmd.status.did_succeed
+    text = cmd.replies.get("text")
+    assert text == "Dome is moving!!!"
+
+
+async def test_command_dome_position_unknown(
+    context: ModbusSlaveContext,
+    actor: ECPActor,
+):
+    context.setValues(1, actor.plc.modbus["dome_closed"].address, [0])
+
+    cmd = await actor.invoke_mock_command("dome status")
+    await cmd
+
+    assert cmd.status.did_succeed
+    text = cmd.replies.get("text")
+    assert text == "Dome position is unknown!!!"
+
+
+async def test_command_dome_stop(actor: ECPActor):
+    await actor.plc.modbus["drive_enabled"].write(1)
+
+    cmd = await actor.invoke_mock_command("dome stop")
+    await cmd
+
+    assert cmd.status.did_succeed
+
+    assert (await actor.plc.modbus["drive_enabled"].read(use_cache=False)) == 0
+
+
+async def test_command_dome_reset(context: ModbusSlaveContext, actor: ECPActor):
+    context.setValues(1, actor.plc.modbus["dome_error"].address, [1])
+
+    cmd = await actor.invoke_mock_command("dome reset")
+    await cmd
+
+    assert cmd.status.did_succeed
+
+    assert (await actor.plc.modbus["dome_error"].read(use_cache=False)) == 0
 
 
 async def test_command_dome_open(actor: ECPActor, mocker: MockerFixture):

--- a/tests/test_command_heartbeat.py
+++ b/tests/test_command_heartbeat.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 
 async def test_command_heartbeat(actor: ECPActor, mocker: MockerFixture):
-    hb_set_mock = mocker.patch.object(actor.plc.modbus["hb_set"], "set")
+    hb_set_mock = mocker.patch.object(actor.plc.modbus["hb_set"], "write")
 
     cmd = await actor.invoke_mock_command("heartbeat")
     await cmd
@@ -29,7 +29,7 @@ async def test_command_heartbeat(actor: ECPActor, mocker: MockerFixture):
 
 
 async def test_command_heartbeat_fails(actor: ECPActor, mocker: MockerFixture):
-    mocker.patch.object(actor.plc.modbus["hb_set"], "set", side_effect=Exception)
+    mocker.patch.object(actor.plc.modbus["hb_set"], "write", side_effect=Exception)
 
     cmd = await actor.invoke_mock_command("heartbeat")
     await cmd

--- a/tests/test_command_modbus.py
+++ b/tests/test_command_modbus.py
@@ -14,6 +14,8 @@ from pytest_mock import MockerFixture
 
 
 if TYPE_CHECKING:
+    from pymodbus.datastore import ModbusSlaveContext
+
     from lvmecp.actor import ECPActor
 
 
@@ -86,3 +88,18 @@ async def test_modbus_write_register_fails(actor: ECPActor, mocker: MockerFixtur
 
     assert write_cmd.status.did_fail
     assert "cannot write" in write_cmd.replies.get("error")
+
+
+async def test_modbus_write_unknown_register(
+    context: ModbusSlaveContext,
+    actor: ECPActor,
+):
+    cmd = await actor.invoke_mock_command(
+        "modbus write --register-type coil --allow-unknown 999 1"
+    )
+    await cmd
+
+    assert cmd.status.did_succeed
+
+    register = cmd.replies.get("register")
+    assert register == {"name": "coil_999", "address": 999, "value": True}

--- a/tests/test_command_modbus.py
+++ b/tests/test_command_modbus.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# @Author: José Sánchez-Gallego (gallegoj@uw.edu)
+# @Date: 2024-12-28
+# @Filename: test_command_modbus.py
+# @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pytest_mock import MockerFixture
+
+
+if TYPE_CHECKING:
+    from lvmecp.actor import ECPActor
+
+
+async def test_command_modbus_read(actor: ECPActor):
+    read_cmd = await actor.invoke_mock_command("modbus read door_locked")
+    await read_cmd
+
+    assert read_cmd.status.did_succeed
+    assert read_cmd.replies.get("register")["value"]
+
+
+async def test_command_modbus_read_address(actor: ECPActor):
+    read_cmd = await actor.invoke_mock_command("modbus read --register-type coil 1")
+    await read_cmd
+
+    assert read_cmd.status.did_succeed
+
+    assert read_cmd.replies.get("register")["name"] == "door_closed"
+    assert read_cmd.replies.get("register")["value"]
+
+
+async def test_command_modbus_read_address_no_register_type(actor: ECPActor):
+    read_cmd = await actor.invoke_mock_command("modbus read 1")
+    await read_cmd
+
+    assert read_cmd.status.did_fail
+
+    assert "--register-type must be specified" in read_cmd.replies.get("error")
+
+
+async def test_command_modbus_read_bad_register(actor: ECPActor):
+    read_cmd = await actor.invoke_mock_command("modbus read bad_register")
+    await read_cmd
+
+    assert read_cmd.status.did_fail
+
+    assert "not found" in read_cmd.replies.get("error")
+
+
+async def test_modbus_write_register(actor: ECPActor):
+    pre_value = await actor.plc.modbus["motor_direction"].read(use_cache=False)
+    assert pre_value == 0
+
+    write_cmd = await actor.invoke_mock_command("modbus write motor_direction 1")
+    await write_cmd
+
+    assert write_cmd.status.did_succeed
+
+    new_value = await actor.plc.modbus["motor_direction"].read(use_cache=False)
+    assert new_value == 1
+
+
+async def test_modbus_write_register_readonly(actor: ECPActor):
+    write_cmd = await actor.invoke_mock_command("modbus write door_locked 1")
+    await write_cmd
+
+    assert write_cmd.status.did_fail
+    assert "is read-only" in write_cmd.replies.get("error")
+
+
+async def test_modbus_write_register_fails(actor: ECPActor, mocker: MockerFixture):
+    mocker.patch.object(
+        actor.plc.modbus["motor_direction"],
+        "write",
+        side_effect=ValueError("cannot write"),
+    )
+
+    write_cmd = await actor.invoke_mock_command("modbus write motor_direction 1")
+    await write_cmd
+
+    assert write_cmd.status.did_fail
+    assert "cannot write" in write_cmd.replies.get("error")

--- a/tests/test_modbus.py
+++ b/tests/test_modbus.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# @Author: José Sánchez-Gallego (gallegoj@uw.edu)
+# @Date: 2024-12-29
+# @Filename: test_modbus.py
+# @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
+
+from __future__ import annotations
+
+import asyncio
+
+from typing import TYPE_CHECKING, cast
+
+import pytest
+from pytest_mock import MockerFixture
+
+import lvmecp.modbus
+from lvmecp.modbus import ModbusRegister, RegisterModes
+
+
+if TYPE_CHECKING:
+    from pymodbus.datastore import ModbusSlaveContext
+
+    from lvmecp.modbus import Modbus
+
+
+async def test_modbus_read(modbus: Modbus):
+    resp = await modbus.read_register("door_locked")
+    assert resp == 1
+
+
+@pytest.mark.parametrize(
+    "register_type",
+    ["coil", "discrete_input", "input_register", "holding_register"],
+)
+async def test_modbus_register_read(
+    context: ModbusSlaveContext,
+    modbus: Modbus,
+    register_type: str,
+):
+    is_discrete = register_type in ["coil", "discrete_input"]
+
+    write_func_code = 1
+    if register_type == "discrete_input":
+        write_func_code = 2
+    elif register_type == "holding_register":
+        write_func_code = 3
+    elif register_type == "input_register":
+        write_func_code = 4
+
+    context.setValues(write_func_code, 99, [1 if is_discrete else 101])
+
+    register = ModbusRegister(
+        modbus,
+        name="test_register",
+        address=99,
+        mode=cast(RegisterModes, register_type),
+        count=1,
+        readonly=True,
+    )
+
+    resp = await register.read(use_cache=False)
+    assert resp == (1 if is_discrete else 101)
+
+
+async def test_modbus_register_read_decoder_float_32bit(
+    context: ModbusSlaveContext,
+    modbus: Modbus,
+):
+    context.setValues(3, 99, [4000, 16000])
+
+    register = ModbusRegister(
+        modbus,
+        name="test_register",
+        address=99,
+        mode="holding_register",
+        count=2,
+        readonly=True,
+        decoder="float_32bit",
+    )
+
+    resp = await register.read(use_cache=False)
+
+    assert resp == 0.250
+
+
+@pytest.mark.parametrize("register_type", ["coil", "holding_register"])
+async def test_modbus_register_write(
+    context: ModbusSlaveContext,
+    modbus: Modbus,
+    register_type: str,
+):
+    is_discrete = register_type in ["coil", "discrete_input"]
+    write_func_code = 1 if is_discrete else 3
+
+    register = ModbusRegister(
+        modbus,
+        name="test_register",
+        address=99,
+        mode=cast(RegisterModes, register_type),
+        count=1,
+        readonly=False,
+    )
+
+    await register.write(1 if is_discrete else 101)
+
+    value = context.getValues(write_func_code, 99)
+    assert value[0] == (1 if is_discrete else 101)
+
+
+@pytest.mark.parametrize("register_type", ["discrete_input", "input_register"])
+async def test_modbus_register_write_on_readonly(modbus: Modbus, register_type: str):
+    register = ModbusRegister(
+        modbus,
+        name="test_register",
+        address=99,
+        mode=cast(RegisterModes, register_type),
+        count=1,
+        readonly=False,
+    )
+
+    with pytest.raises(ValueError) as err:
+        await register.write(1)
+
+    assert "is read-only" in str(err.value)
+
+
+async def test_modbus_connection_fails(modbus: Modbus, mocker: MockerFixture):
+    mocker.patch.object(modbus.client, "connect", side_effect=ConnectionError)
+
+    with pytest.raises(ConnectionError):
+        await modbus.read_register("door_locked")
+
+
+async def test_modbus_connection_timeouts(modbus: Modbus, mocker: MockerFixture):
+    mocker.patch.object(modbus.client, "connect", side_effect=asyncio.TimeoutError)
+
+    with pytest.raises(ConnectionError):
+        await modbus.read_register("door_locked")
+
+
+async def test_modbus_lock_release(modbus: Modbus, mocker: MockerFixture):
+    mocker.patch.object(lvmecp.modbus, "CONNECTION_TIMEOUT", 0.1)
+
+    async with modbus:
+        assert modbus.client.connected
+        assert modbus.lock.locked()
+
+        await asyncio.sleep(0.2)
+
+        assert not modbus.client.connected
+        assert not modbus.lock.locked()


### PR DESCRIPTION
This is a major refactor of how the `Modbus` and `ModbusRegister` classes work:

- Performance has been greatly improved, with `Modbus.get_all()` going from taking ~0.6 seconds to under 0.1. The main change is that the register and coil blocks are now read completely, in chunks as large as the device will accept, as opposed to before, when we would read each variable with one read command (although the connection was not closed in between).
- The caching mechanism has been improved and now works as expected. The default cache timeout is 1 second.
- The PLC variable list has been updated and now matches Felipe's list.
- Various renamings of methods and variables.
- Added a low-level `modbus` actor command to read/set Modbus variables (even those not defined in the PLC list).
- Improved the simulator to better handle overrides and events that trigger a change in the internal state of the context.
- Improve the engineering mode commands.
- Improve test coverage.